### PR TITLE
Add new lang code

### DIFF
--- a/language_set_full.json
+++ b/language_set_full.json
@@ -6004,6 +6004,7 @@
     "smb": "Simbari",
     "smc": "Som",
     "smd": "Sama",
+    "sme": "Northern Sami",
     "smf": "Auwe",
     "smg": "Simbali",
     "smh": "Samei",


### PR DESCRIPTION
This PR adds the language code for the Nothern Sami. The two other codes `qhe` and `qtd` are what is called "private usage" so I did not add them.