### PR TITLE
Add part-of-speech-tagging

### DIFF
--- a/task_set.json
+++ b/task_set.json
@@ -37,6 +37,7 @@
         "options": [
             "coreference-resolution",
             "named-entity-recognition",
+            "part-of-speech-tagging",
             "parsing",
             "other"
         ]


### PR DESCRIPTION
Add `part-of-speech-tagging` in the `structure-prediction` task ids set