### PR TITLE
Fix extended datasets & autofill size info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,142 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
 .idea
 metadata_*.json
 datasets/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyyaml
-datasets
+datasets==1.7.0
 streamlit
 langcodes[data]

--- a/tagging_app.py
+++ b/tagging_app.py
@@ -352,6 +352,8 @@ current_size_cats = state.get("size_categories") or ["unknown"]
 ok, nonok = split_known(current_size_cats, known_size_categories)
 if len(nonok) > 0:
     leftcol.markdown(f"**Found bad codes in existing tagset**:\n{nonok}")
+else:
+    state["size_categories"] = [initial_size_cats]
 
 
 ########################

--- a/tagging_app.py
+++ b/tagging_app.py
@@ -314,17 +314,16 @@ if "original" in state["source_datasets"]:
     pre_select_ext_a += ["original"]
 if any([p.startswith("extended") for p in state["source_datasets"]]):
     pre_select_ext_a += ["extended"]
-state["extended"] = multiselect(
+state["source_datasets"] = multiselect(
     leftcol,
     "Relations to existing work",
     "Does the dataset contain original data and/or was it extended from other datasets?",
     values=pre_select_ext_a,
     valid_set=["original", "extended"],
 )
-state["source_datasets"] = ["original"] if "original" in state["extended"] else []
 
-if "extended" in state["extended"]:
-    pre_select_ext_b = [p.split("|")[1] for p in state["source_datasets"] if p.startswith("extended")]
+if "extended" in state["source_datasets"]:
+    pre_select_ext_b = [p.split("|")[1] for p in state["source_datasets"] if p.startswith("extended|")]
     extended_sources = multiselect(
         leftcol,
         "Linked datasets",
@@ -332,13 +331,8 @@ if "extended" in state["extended"]:
         values=pre_select_ext_b,
         valid_set=dataset_ids + ["other"],
     )
-    if "other" in extended_sources:
-        other_extended_sources = leftcol.text_input(
-            "You selected 'other' dataset. Please enter a short hyphen-separated description:",
-            value="my-dataset",
-        )
-        leftcol.write(f"Registering other-{other_extended_sources} dataset")
-        extended_sources[extended_sources.index("other")] = f"other-{other_extended_sources}"
+    # flush placeholder
+    state["source_datasets"].remove("extended")
     state["source_datasets"] += [f"extended|{src}" for src in extended_sources]
 
 


### PR DESCRIPTION
This PR fixes a bug reported [huggingface/datasets/#2440](https://github.com/huggingface/datasets/issues/2440) where a spurious `extended` field was getting added to the YAML tags, which breaks the CI on `datasets`. The corrected output is shown below.

![Screen Shot 2021-06-08 at 2 09 11 pm](https://user-images.githubusercontent.com/26859204/121185256-27824400-c866-11eb-9159-1f6e55c7e186.png)


I've also taken the liberty to:

- Pin the `datasets` version
- Autofill the size categories (previously this had to be copy-pasted for new datasets)