### PR TITLE
Add pretty_name tag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyyaml
-datasets==1.7.0
+datasets==1.9.0
 streamlit
 langcodes[data]

--- a/tagging_app.py
+++ b/tagging_app.py
@@ -193,6 +193,15 @@ Here is the matching yaml block:
 
 leftcol, _, rightcol = st.beta_columns([12, 1, 12])
 
+#
+# DATASET NAME
+#
+leftcol.markdown("### Dataset name")
+state["pretty_name"] = leftcol.text_area(
+    "Pick a nice descriptive name for the dataset",
+)
+
+
 
 #
 # TASKS


### PR DESCRIPTION
This PR adds a textbox for users to add a `pretty_name` field that was introduced in v1.9 of `datasets`.

![Screen Shot 2021-07-09 at 18 09 53](https://user-images.githubusercontent.com/26859204/125107385-1042aa80-e0e1-11eb-9b03-3d7a0d9a05bb.png)
